### PR TITLE
Travis: Use codecov instead of coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then virtualenv venv -p $FORMULA; fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then source venv/bin/activate; fi
   - pip install -U pip
-  - pip install -U coveralls
+  - pip install -U codecov
 install:
   - pip install -Ur requirements.txt
   - python setup.py develop
@@ -44,4 +44,4 @@ script:
   - if [[ $TRAVIS_PYTHON_VERSION == 3.5 && $TRAVIS_OS_NAME != "osx" ]]; then $RUN_TESTS --enable-functional; fi
   - if [[ $TRAVIS_PYTHON_VERSION != 3.5 || $TRAVIS_OS_NAME == "osx" ]]; then $RUN_TESTS; fi
 after_success:
-  - coveralls
+  - codecov

--- a/README.md
+++ b/README.md
@@ -402,8 +402,8 @@ Project License can be found [here](LICENSE.md).
 [travis-link]:     https://travis-ci.org/nvbn/thefuck
 [appveyor-badge]:  https://img.shields.io/appveyor/ci/nvbn/thefuck.svg?label=windows%20build
 [appveyor-link]:   https://ci.appveyor.com/project/nvbn/thefuck
-[coverage-badge]:  https://img.shields.io/coveralls/nvbn/thefuck.svg
-[coverage-link]:   https://coveralls.io/github/nvbn/thefuck
+[coverage-badge]:  http://codecov.io/github/josephfrazier/thefuck/coverage.svg
+[coverage-link]:   http://codecov.io/github/josephfrazier/thefuck
 [license-badge]:   https://img.shields.io/badge/license-MIT-007EC7.svg
 [examples-link]:   https://raw.githubusercontent.com/nvbn/thefuck/master/example.gif
 [homebrew]:        http://brew.sh/


### PR DESCRIPTION
Changes modeled after:
https://github.com/codecov/example-python/blob/3f28e93cbc1d266c30a5bdf43126ed44fbeb009d/.travis.yml
